### PR TITLE
Add Hasura CLI to Underwriter and Hasura image that waits for Postgres.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This repo contains images hosted on Docker Hub
 ### Add New Image
 1. Add new folder containing `Dockerfile` (`<Dockerfile directory>`)
 1. Log into [docker hub](https://hub.docker.com/), navigate to statestitle organization
-1. Create new **Automated Build** under statestitle organization
-1. Customize autobuild tags, change master branch Dockerfile Location to `<Dockerfile directory>`
+1. Create new **Repository** under statestitle organization
+1. Customize autobuild tags, change master branch Dockerfile Location to `<Dockerfile directory>/Dockerfile`
 1. Build image locally
 
 	```

--- a/hasura/Dockerfile
+++ b/hasura/Dockerfile
@@ -1,4 +1,3 @@
 FROM hasura/graphql-engine:v1.0.0-beta.3
 COPY serve-graphql-when-postgres-available /serve-graphql-when-postgres-available
 CMD /serve-graphql-when-postgres-available
-ENV HASURA_GRAPHQL_DATABASE_URL postgres://graph_test:graph_test@localhost:5432/graph_test

--- a/hasura/Dockerfile
+++ b/hasura/Dockerfile
@@ -1,4 +1,4 @@
 FROM hasura/graphql-engine:v1.0.0-beta.3
-COPY wait-for-postgres /wait-for-postgres
-CMD /wait-for-postgres
+COPY serve-graphql-when-postgres-available /serve-graphql-when-postgres-available
+CMD /serve-graphql-when-postgres-available
 ENV HASURA_GRAPHQL_DATABASE_URL postgres://graph_test:graph_test@localhost:5432/graph_test

--- a/hasura/Dockerfile
+++ b/hasura/Dockerfile
@@ -1,0 +1,4 @@
+FROM hasura/graphql-engine:v1.0.0-beta.3
+COPY wait-for-postgres /wait-for-postgres
+CMD /wait-for-postgres
+ENV HASURA_GRAPHQL_DATABASE_URL postgres://graph_test:graph_test@localhost:5432/graph_test

--- a/hasura/serve-graphql-when-postgres-available
+++ b/hasura/serve-graphql-when-postgres-available
@@ -17,7 +17,7 @@ wait_for_postgres() {
     echo "waiting up to $TIMEOUT seconds for postgres to be ready"
     for i in `seq 1 $TIMEOUT`;
     do
-        nc "$POSTGRES_HOSTNAME" $POSTGRES_PORT > /dev/null 2>&1 && echo "postgres is ready" && sleep 3 && return
+        nc -z "$POSTGRES_HOSTNAME" $POSTGRES_PORT > /dev/null 2>&1 && echo "postgres is ready" && sleep 3 && return
         sleep 1
     done
     echo "failed waiting for postgres" && exit 1

--- a/hasura/serve-graphql-when-postgres-available
+++ b/hasura/serve-graphql-when-postgres-available
@@ -9,7 +9,7 @@ wait_for_postgres() {
     echo "waiting up to $TIMEOUT seconds for postgres to be ready"
     for i in `seq 1 $TIMEOUT`;
     do
-        nc localhost 5432 > /dev/null 2>&1 && echo "postgres is ready" && return
+        nc localhost 5432 > /dev/null 2>&1 && echo "postgres is ready" && sleep 3 && return
         sleep 1
     done
     echo "failed waiting for postgres" && exit 1

--- a/hasura/serve-graphql-when-postgres-available
+++ b/hasura/serve-graphql-when-postgres-available
@@ -4,12 +4,20 @@
 set -e
 
 wait_for_postgres() {
+    if test -z "$POSTGRES_HOSTNAME"; then
+        POSTGRES_HOSTNAME="localhost"
+    fi
+
+    if test -z "$POSTGRES_PORT"; then
+        POSTGRES_PORT="5432"
+    fi
+
     local TIMEOUT=120
     
     echo "waiting up to $TIMEOUT seconds for postgres to be ready"
     for i in `seq 1 $TIMEOUT`;
     do
-        nc localhost 5432 > /dev/null 2>&1 && echo "postgres is ready" && sleep 3 && return
+        nc "$POSTGRES_HOSTNAME" $POSTGRES_PORT > /dev/null 2>&1 && echo "postgres is ready" && sleep 3 && return
         sleep 1
     done
     echo "failed waiting for postgres" && exit 1

--- a/hasura/wait-for-postgres
+++ b/hasura/wait-for-postgres
@@ -1,0 +1,19 @@
+#!/bin/sh
+# This is based on https://github.com/hasura/graphql-engine/blob/8282e92408d4dc6a124a993d25c0551ee896b5cd/scripts/cli-migrations/docker-entrypoint.sh#L25
+
+set -e
+
+wait_for_postgres() {
+    local TIMEOUT=120
+    
+    echo "waiting up to $TIMEOUT seconds for postgres to be ready"
+    for i in `seq 1 $TIMEOUT`;
+    do
+        nc localhost 5432 > /dev/null 2>&1 && echo "postgres is ready" && return
+        sleep 1
+    done
+    echo "failed waiting for postgres" && exit 1
+}
+
+wait_for_postgres
+graphql-engine serve

--- a/underwriter/Dockerfile
+++ b/underwriter/Dockerfile
@@ -163,7 +163,7 @@ RUN set -ex \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
 
 ### 3a. Hasura CLI
-RUN curl -L https://github.com/hasura/graphql-engine/raw/master/cli/get.sh | bash
+RUN curl -L https://github.com/hasura/graphql-engine/raw/master/cli/get.sh | bash \
   && hasura version
 
 ### 4. CircleCI

--- a/underwriter/Dockerfile
+++ b/underwriter/Dockerfile
@@ -164,6 +164,7 @@ RUN set -ex \
 
 ### 3a. Hasura CLI
 RUN curl -L https://github.com/hasura/graphql-engine/raw/master/cli/get.sh | bash
+  && hasura version
 
 ### 4. CircleCI
 ### The following is copied from: https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/python/images/3.7.0/Dockerfile

--- a/underwriter/Dockerfile
+++ b/underwriter/Dockerfile
@@ -162,6 +162,9 @@ RUN set -ex \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
 
+### 3a. Hasura CLI
+RUN curl -L https://github.com/hasura/graphql-engine/raw/master/cli/get.sh | bash
+
 ### 4. CircleCI
 ### The following is copied from: https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/python/images/3.7.0/Dockerfile
 # make Apt non-interactive


### PR DESCRIPTION
I am happy to split this up into two pull requests if that makes more sense.

Once this is merged and the `statestitle/hasura` Docker image is available, we will use it for CI in place of the standard Hasura image. Given that and the Hasura CLI, we should be able to [run migrations and get tests working in CI](https://github.com/StatesTitle/underwriter/pull/1290).

~**Note**: I don't think I have sufficient permissions to create a new Dockerhub repository as described in the README. Or maybe Dockerhub's Repositories are different from the Automated Builds referred to in the README? I didn't see anything about them.~