### PR TITLE
chore(circleci): update yarn and node versions

### DIFF
--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -1,13 +1,13 @@
 # Base consists of the following images:
-# https://github.com/nodejs/docker-node/blob/master/10/stretch/Dockerfile
-# https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/node/images/10.6.0-stretch/Dockerfile
+# https://github.com/nodejs/docker-node/blob/master/12/stretch/Dockerfile
+# https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/node/images/12.10.0-stretch/Dockerfile
 
-FROM circleci/node:10.6.0-stretch AS base
+FROM circleci/node:12.10.0-stretch AS base
 FROM circleci/python:3.7.0
 
 RUN curl https://cli-assets.heroku.com/install.sh | sh
 
-ENV YARN_VERSION 1.7.0
+ENV YARN_VERSION 1.17.3
 
 COPY --from=base /usr/local/bin/node /usr/local/bin/node
 COPY --from=base /opt/yarn-v$YARN_VERSION /opt/yarn-v$YARN_VERSION


### PR DESCRIPTION
updating circleci image to use node 12 which will be new LTS version.