### PR TITLE
Removal of unneeded package install.

### DIFF
--- a/underwriter/Dockerfile
+++ b/underwriter/Dockerfile
@@ -103,8 +103,7 @@ RUN set -ex; \
 ### https://github.com/nodejs/docker-node/blob/master/12/stretch-slim/Dockerfile
 ENV NODE_VERSION 12.10.0
 
-RUN buildDeps='xz-utils' \
-    && ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
       amd64) ARCH='x64';; \
       ppc64el) ARCH='ppc64le';; \
@@ -115,7 +114,7 @@ RUN buildDeps='xz-utils' \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -ex \
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr $buildDeps --no-install-recommends \
+    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
@@ -140,7 +139,6 @@ RUN buildDeps='xz-utils' \
     && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
     && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
     && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-    && apt-get purge -y --auto-remove $buildDeps \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 ENV YARN_VERSION 1.17.3


### PR DESCRIPTION
Somehow this led to the intermittent failure discussed here:
https://statestitle.slack.com/archives/CJ4EXPZT3/p1572977235086100

These utilities are already installed as part of build-essential at the top of file.
Pruning later removes extra packages (including g++) that we may need to build some yarn packages.

Hopefully by removing this, we can bulletproof against running into this in the future.