### PR TITLE
Update to the latest cumulative update version of MSSQL server 2017.

### DIFF
--- a/resware-mssql/Dockerfile
+++ b/resware-mssql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mssql/server:2017-CU17-ubuntu
+FROM mcr.microsoft.com/mssql/server:2017-CU18-ubuntu-16.04
 
 # -y is not sufficient for upgrading SQL server
 ENV ACCEPT_EULA Y


### PR DESCRIPTION
I don't really expect this to reduce or eliminate the MSSQL-related CI failures we've been experiencing, but it seems like a reasonable first thing to try since it's easy.