### PR TITLE
(small) Don't install Hasura in underwriter image.

### DIFF
--- a/underwriter/Dockerfile
+++ b/underwriter/Dockerfile
@@ -161,10 +161,6 @@ RUN set -ex \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
 
 
-### 3a. Hasura CLI
-RUN curl -L https://github.com/hasura/graphql-engine/raw/master/cli/get.sh | bash \
-  && hasura version
-
 ### 4. CircleCI
 ### The following is copied from: https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/python/images/3.7.0/Dockerfile
 # make Apt non-interactive


### PR DESCRIPTION
We no longer use Hasura so let's stop installing the CLI. We can always revert this commit if we decide to use Hasura again in the future.