### PR TITLE
add simple circleci-heroku Dockerfile

### DIFF
--- a/circleci-heroku/Dockerfile
+++ b/circleci-heroku/Dockerfile
@@ -1,0 +1,3 @@
+FROM cimg/base:stable
+
+RUN curl https://cli-assets.heroku.com/install.sh | sh


### PR DESCRIPTION
Background & Summary
====================

I'm working on the Heroku/Docker CircleCI deployment orb and want to get
away from installing Heroku CLI on job each run.

Solution
========

I'm going to use the image generated by this Dockerfile as the primary
executor for the Heroku/Docker CircleCI deployment orb's job(s).