### PR TITLE
athena: postgres12 docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This repo contains images hosted on Docker Hub
 	```
 	 docker build --tag statestitle/<Dockerfile directory> ./<Dockerfile directory>
 	```
+1. Login to docker
+    ```
+	 docker login
+	```
 1. Push initial image
 
 	```

--- a/postgres12/01-create-users-and-databases.sh
+++ b/postgres12/01-create-users-and-databases.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+/wait-for-postgres
+for db in ${POSTGRES12_DATABASE_NAMES}; do
+	createuser -U postgres -s ${db}
+	createdb -U postgres ${db} --owner=${db}
+done

--- a/postgres12/10-possibly-load-backup.sh
+++ b/postgres12/10-possibly-load-backup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if ls /dumps/*.dump 1> /dev/null 2>&1; then
+    /wait-for-postgres
+    for f in /dumps/*.dump ; do
+        service_name=$(echo ${f} | sed -e 's/\/dumps\/latest-st-// ; s/.dump// ; s/--staging// ; s/-/_/')
+        if [[ "$POSTGRES12_DATABASE_NAMES" == *"$service_name"* ]] ; then
+            # Ignore errors in the restore as it attempts to drop tables first
+            pg_restore --verbose --clean --no-acl --no-owner -U postgres -d "$service_name" "$f" || true
+        fi
+    done
+fi

--- a/postgres12/Dockerfile
+++ b/postgres12/Dockerfile
@@ -1,0 +1,5 @@
+FROM postgres:12.3-alpine
+
+COPY wait-for-postgres /wait-for-postgres
+COPY 01-create-users-and-databases.sh 10-possibly-load-backup.sh /docker-entrypoint-initdb.d/
+VOLUME /dumps

--- a/postgres12/README.md
+++ b/postgres12/README.md
@@ -1,0 +1,7 @@
+# postgres
+
+This image is used to load multiple databases running Postgres 12.
+
+### Required Environment Variables
+
+- `POSTGRES12_DATABASE_NAMES` a space delimited list of the database names

--- a/postgres12/wait-for-postgres
+++ b/postgres12/wait-for-postgres
@@ -1,0 +1,15 @@
+#!/bin/bash
+i="0"
+
+while [ $i -lt 10 ] ; do
+    psql -U postgres -c 'select 1;' > /dev/null 2>&1
+    if [ $? -eq 0 ] ; then
+        exit 0
+    fi
+    i=$[$i+1]
+    sleep 1
+done
+
+set -e
+psql -U postgres -c 'select 1;'
+


### PR DESCRIPTION
This copies the existing `postgres11` settings and `Dockerfile` to a new `postgres12` folder, in order to enable using `postgres12` on CircleCI for `build_and_test` and for local development. We currently use PostgreSQL 12.3 in our Heroku add-on for `athena_logic` in staging, so this would let our development and builds match our deployments. For comms and DnD, the staging environment is still using 11.8, but we should update their DBs to 12.3 to be consistent.

The only changes between this and `postgres11` currently are renaming `POSTGRES11_DATABASE_NAMES` to `POSTGRES12_DATABASE_NAMES` and setting the `FROM` in the `Dockerfile` to `12.3-alpine`.