### PR TITLE
underwriter: Add personal package archive (ppa) repository for FreeTDS so we get a newer version.

### DIFF
--- a/underwriter/Dockerfile
+++ b/underwriter/Dockerfile
@@ -277,7 +277,8 @@ RUN buildDeps='automake bison flex libtool libboost-dev libboost-filesystem-dev 
     && rm -rf /thrift-build/
 
 # unixodbc-dev is needed for pyodbc
-RUN apt-get update && apt-get install -y unixodbc-dev unixodbc tdsodbc freetds-dev freetds-bin g++
+# we add a ppa for freetds to get a more up-to-date version than we get from apt-get by default
+RUN add-apt-repository ppa:rs-vilt/freetds && apt-get update && apt-get install -y unixodbc-dev unixodbc tdsodbc freetds-dev freetds-bin g++
 RUN echo "[FreeTDS]" >> /etc/odbcinst.ini
 RUN echo "Description=FreeTDS Driver" >> /etc/odbcinst.ini
 RUN echo "Driver=/usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so" >> /etc/odbcinst.ini

--- a/underwriter/Dockerfile
+++ b/underwriter/Dockerfile
@@ -10,6 +10,8 @@ FROM heroku/heroku:16
 
 RUN apt-get update -y
 RUN apt-get -y install software-properties-common libffi-dev libssl-dev build-essential wget
+# we add a ppa for freetds to get a more up-to-date version than we get from apt-get by default
+RUN add-apt-repository ppa:rs-vilt/freetds
 RUN curl https://cli-assets.heroku.com/install.sh | sh
 
 ### 2. Python
@@ -277,8 +279,7 @@ RUN buildDeps='automake bison flex libtool libboost-dev libboost-filesystem-dev 
     && rm -rf /thrift-build/
 
 # unixodbc-dev is needed for pyodbc
-# we add a ppa for freetds to get a more up-to-date version than we get from apt-get by default
-RUN add-apt-repository ppa:rs-vilt/freetds && apt-get update && apt-get install -y unixodbc-dev unixodbc tdsodbc freetds-dev freetds-bin g++
+RUN apt-get update && apt-get install -y unixodbc-dev unixodbc tdsodbc freetds-dev freetds-bin g++
 RUN echo "[FreeTDS]" >> /etc/odbcinst.ini
 RUN echo "Description=FreeTDS Driver" >> /etc/odbcinst.ini
 RUN echo "Driver=/usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so" >> /etc/odbcinst.ini


### PR DESCRIPTION
This archive has version 1.00.15-2 whereas the default from apt-get is 0.91-6.1build1.

Locally, we use the FreeTDS version from Homebrew, which is 1.0+. In the older version, values are parsed differently when querying the ResWare DB in API+ (specifically numbers that should be Decimals are instead floats, and uuids are instead strings). This causes test failures in CI that are not reproducible locally.

The update was tested in this branch - https://github.com/StatesTitle/underwriter/pull/6249