### PR TITLE
feat(dockerhub): add thrift base image based on python slim

### DIFF
--- a/thrift/Dockerfile
+++ b/thrift/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.7.8-slim
+
+ENV MD5_HASH 38a27d391a2b03214b444cb13d5664f1
+ENV THRIFT_VERSION 0.13.0
+
+RUN set -x && \
+    dependencies='wget automake bison flex g++ git libboost-all-dev libevent-dev libssl-dev libtool make pkg-config' && \
+    apt-get update --fix-missing && apt-get install --fix-broken -y --no-install-recommends $dependencies && \
+    wget --output-document /tmp/thrift-${THRIFT_VERSION}.tar.gz https://downloads.apache.org/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz && \
+    [ $(md5sum /tmp/thrift-${THRIFT_VERSION}.tar.gz | cut -d' ' -f1) = $MD5_HASH ] && \
+    tar -xf /tmp/thrift-${THRIFT_VERSION}.tar.gz -C /tmp && \
+    rm /tmp/thrift-${THRIFT_VERSION}.tar.gz && \
+    cd /tmp/thrift-${THRIFT_VERSION} && \
+    ./bootstrap.sh && \
+    ./configure --prefix=/usr/local/ --enable-libs=no && \
+    make && \
+    make install && \
+    rm -rf /tmp/thrift-${THRIFT_VERSION} && \
+    apt-get purge -y --auto-remove $dependencies
+
+CMD ["sh", "-c", "echo thrift v.${THRIFT_VERSION}"]

--- a/thrift/Dockerfile
+++ b/thrift/Dockerfile
@@ -18,4 +18,4 @@ RUN set -x && \
     rm -rf /tmp/thrift-${THRIFT_VERSION} && \
     apt-get purge -y --auto-remove $dependencies
 
-CMD ["sh", "-c", "echo thrift v.${THRIFT_VERSION}"]
+CMD echo "thrift v.$THRIFT_VERSION"


### PR DESCRIPTION
This is a no frills implementation of a thrift base image. It uses `python:3.7.8-slim`, the same base image as currently deployed thrift APIs.