### PR TITLE
Upgrade Node (12.21.0) and Yarn (1.22.10)

### DIFF
--- a/underwriter/Dockerfile
+++ b/underwriter/Dockerfile
@@ -97,9 +97,9 @@ RUN set -ex; \
 		\) -exec rm -rf '{}' +; \
 	rm -f get-pip.py
 
-### 3. Node 12.19.0 + Yarn 1.22.5
+### 3. Node 12.21.0 + Yarn 1.22.10
 ### https://github.com/nodejs/docker-node/blob/master/12/stretch-slim/Dockerfile
-ENV NODE_VERSION 12.19.0
+ENV NODE_VERSION 12.21.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -149,7 +149,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && node --version \
     && npm --version
 
-ENV YARN_VERSION 1.22.5
+ENV YARN_VERSION 1.22.10
 
 RUN set -ex \
   && savedAptMark="$(apt-mark showmanual)" \


### PR DESCRIPTION
This upgrades node and yarn to match the [`engine` versions declared in underwriter](https://github.com/StatesTitle/underwriter/blob/master/package.json#L57).

I ran into this error while adding a new Circle CI job that runs `yarn install`:
```
yarn install v1.22.5
[1/5] Validating package.json...
error ***********@0.0.0: The engine "node" is incompatible with this module. Expected version "12.21.0". Got "12.19.0"
error ***********@0.0.0: The engine "yarn" is incompatible with this module. Expected version "1.22.10". Got "1.22.5"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

Exited with code exit status 1
```

Maybe this fixes it? 🤷 