### PR TITLE
[DevEx] Switched circleci-heroku docker image to use cimg/python:3.7 as base

### DIFF
--- a/circleci-heroku/Dockerfile
+++ b/circleci-heroku/Dockerfile
@@ -1,3 +1,3 @@
-FROM cimg/base:stable
+FROM cimg/python:3.7
 
 RUN curl https://cli-assets.heroku.com/install.sh | sh


### PR DESCRIPTION
We are starting to run some of our python helper scripts in the `heroku_docker/build_deploy_release` CircleCI jobs, and we will be using more and more of these to help with other tasks like sending logs to sumo during steps where we use timing. Eventually, we'll want to install the tools using something like `pipenv` on the image itself. For now, until we have something in place to auto-update the images when the code is updated, we'll be doing that in the CircleCI steps.