### PR TITLE
Update underwriter NODE_VERSION to 12.22.3

### DIFF
--- a/underwriter/Dockerfile
+++ b/underwriter/Dockerfile
@@ -99,9 +99,9 @@ RUN set -ex; \
 		\) -exec rm -rf '{}' +; \
 	rm -f get-pip.py
 
-### 3. Node 12.21.0 + Yarn 1.22.10
+### 3. Node 12.21.3 + Yarn 1.22.10
 ### https://github.com/nodejs/docker-node/blob/master/12/stretch-slim/Dockerfile
-ENV NODE_VERSION 12.22.1
+ENV NODE_VERSION 12.22.3
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \


### PR DESCRIPTION
Comms smoke tests are failing with the message 
> The engine "node" is incompatible with this module. Expected version "12.22.3". Got "12.22.1"`

It looks like the Dockerfile is out of date again after StatesTitle/underwriter@7b526a5e9f12561f0368e088c5fd4f67ef3a53f8. We saw something similar and fixed it in 
402fa641f6d43081f3eb0aa5de469a2a95647bb.

FYI @strmer15
