### PR TITLE
Remove a temporary echo statement.

### DIFF
--- a/resware-mssql/load-backup.sh
+++ b/resware-mssql/load-backup.sh
@@ -5,8 +5,6 @@ set -e
 CURRENT_BACKUP_FILE_NAME=""
 CURRENT_RESWARE_DATABASE_NAME=""
 
-echo "STKNIGHT1-- AWS_KEY_ID is set to $AWS_ACCESS_KEY_ID" 
-
 # Load history file
 if [ -f ./.load-backup.history ]; then
     . ./.load-backup.history


### PR DESCRIPTION
This reverts StatesTitle/dockerhub#55. It was a temporary echo statement used to debug a problem. @knoight said "i think you can revert it - we’ve learned what the problem is - once we have a potential fix, we should be able to test it without that debug statement, because if it fixes the problem, it will just work."

Maybe a little more info in [this Slack thread](https://statestitle.slack.com/archives/C010MJ7SZN2/p1626974904011200).