### PR TITLE
change circleci/ to cimg/

### DIFF
--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -2,8 +2,8 @@
 # https://github.com/nodejs/docker-node/blob/master/12/stretch/Dockerfile
 # https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/node/images/12.10.0-stretch/Dockerfile
 
-FROM circleci/node:12.10.0-stretch AS base
-FROM circleci/python:3.7.0
+FROM cimg/node:12.10.0-stretch AS base
+FROM cimg/python:3.7.0
 
 RUN curl https://cli-assets.heroku.com/install.sh | sh
 


### PR DESCRIPTION
This change changes `statestitle/cicrcleci` to use `cimg/` instead of `circleci/` since CircleCI introduced the next generation (next-gen) of convenience images and these new images are designed to replace the legacy convenience images that were released during the announcement of CircleCI

The node images now extend the official Ubuntu image.