### PR TITLE
Node 12.22.6

### DIFF
--- a/underwriter/Dockerfile
+++ b/underwriter/Dockerfile
@@ -99,9 +99,9 @@ RUN set -ex; \
 		\) -exec rm -rf '{}' +; \
 	rm -f get-pip.py
 
-### 3. Node 12.22.5 + Yarn 1.22.11
+### 3. Node 12.22.6 + Yarn 1.22.11
 ### https://github.com/nodejs/docker-node/blob/master/12/stretch-slim/Dockerfile
-ENV NODE_VERSION 12.22.5
+ENV NODE_VERSION 12.22.6
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \


### PR DESCRIPTION
* Upgrade to Node 12.22.6 to fix various security vulnerabilities - https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.22.6