### PR TITLE
Add Git to the CircleCI Kubetools Docker Image

### DIFF
--- a/circleci-kubetools/Dockerfile
+++ b/circleci-kubetools/Dockerfile
@@ -22,6 +22,7 @@ RUN make build
 # Build the container
 FROM alpine:3.14.0
 RUN apk --no-cache add ca-certificates && \
+  apk add git && \
   addgroup -S kubetools && adduser -S kubetools -G kubetools
 COPY --from=builder /kubeval/bin/kubeval /usr/bin/kustomize /usr/bin/kubectl ./
 RUN ln -s /kubeval /usr/local/bin/kubeval && \


### PR DESCRIPTION
This PR adds git to the `kubetools` CircleCI docker image. Some CircleCI jobs need to do a git diff so they can run on only changed files and this addition will allow us to do that. 