### PR TITLE
node 16.16.0

### DIFF
--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -20,7 +20,7 @@ RUN sudo apt-get -y install software-properties-common libffi-dev libssl-dev
 
 # In the public image build, this pulls the latest LTS release from cimg-node
 # but we've pinned the version here to keep this to a known good version and not update to a new major version when LTS changes
-ENV NODE_VERSION 16.15.1
+ENV NODE_VERSION 16.16.0
 RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
 	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
 	rm node.tar.xz && \


### PR DESCRIPTION
Node 16.16.0 - https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V16.md#2022-07-07-version-16160-gallium-lts-danielleadams