### PR TITLE
circleci: install azure-cli, bazel prereqs, and github cli

### DIFF
--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -45,3 +45,17 @@ RUN echo "Description=FreeTDS Driver" | sudo tee -a /etc/odbcinst.ini
 RUN echo "Driver=/usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so" | sudo tee -a /etc/odbcinst.ini
 RUN echo "Setup=/usr/lib/x86_64-linux-gnu/odbc/libtdsS.so" | sudo tee -a /etc/odbcinst.ini
 ENV ODBCSYSINI /etc/
+
+# 4. Install the Azure CLI
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+
+# 5. Install Bazel Pre-requisites
+RUN sudo apt-get install --no-install-recommends -y \
+  gettext-base clang
+
+# 6. Install the Github CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+RUN sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+RUN sudo apt update
+RUN sudo apt install gh


### PR DESCRIPTION
Currently, our CI builds download and install the Azure CLI, the Bazel prereqs, and the Github CLI; instead of downloading and installing these on every run, we should put them in our base image.

The Bazel prereqs and the Github CLI take only a few seconds to install, but the Azure CLI can take multiple minutes - see any recent CI build. Installing it in the base image should shave at least 4 minutes off of every build.