### PR TITLE
update link for older thrift version

### DIFF
--- a/thrift/Dockerfile
+++ b/thrift/Dockerfile
@@ -6,7 +6,7 @@ ENV THRIFT_VERSION 0.13.0
 RUN set -x && \
     dependencies='wget automake bison flex g++ git libboost-all-dev libevent-dev libssl-dev libtool make pkg-config' && \
     apt-get update --fix-missing && apt-get install --fix-broken -y --no-install-recommends $dependencies && \
-    wget --output-document /tmp/thrift-${THRIFT_VERSION}.tar.gz https://downloads.apache.org/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz && \
+    wget --output-document /tmp/thrift-${THRIFT_VERSION}.tar.gz https://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz && \
     [ $(md5sum /tmp/thrift-${THRIFT_VERSION}.tar.gz | cut -d' ' -f1) = $MD5_HASH ] && \
     tar -xf /tmp/thrift-${THRIFT_VERSION}.tar.gz -C /tmp && \
     rm /tmp/thrift-${THRIFT_VERSION}.tar.gz && \


### PR DESCRIPTION

thrift 0.13.0 is older version which has been moved to archives and needs to be downloaded from there.