### PR TITLE
Update python version to 3.11 in circle dockerfile

### DIFF
--- a/circleci/Dockerfile
+++ b/circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/python:3.7.13
+FROM cimg/python:3.11.4
 
 ### 1. Underwriter binaries
 


### PR DESCRIPTION

I have already pushed the image to dockerhub which is being used by circleci.