### PR TITLE
Upgrade thrift version for python docker image

### DIFF
--- a/thrift/Dockerfile
+++ b/thrift/Dockerfile
@@ -1,12 +1,12 @@
 FROM python:3.11.4-slim
 
 ENV MD5_HASH 38a27d391a2b03214b444cb13d5664f1
-ENV THRIFT_VERSION 0.13.0
+ENV THRIFT_VERSION 0.20.0
 
 RUN set -x && \
     dependencies='wget automake bison flex g++ git libboost-all-dev libevent-dev libssl-dev libtool make pkg-config' && \
     apt-get update --fix-missing && apt-get install --fix-broken -y --no-install-recommends $dependencies && \
-    wget --output-document /tmp/thrift-${THRIFT_VERSION}.tar.gz https://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz && \
+    wget --output-document /tmp/thrift-${THRIFT_VERSION}.tar.gz https://downloads.apache.org/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz && \
     [ $(md5sum /tmp/thrift-${THRIFT_VERSION}.tar.gz | cut -d' ' -f1) = $MD5_HASH ] && \
     tar -xf /tmp/thrift-${THRIFT_VERSION}.tar.gz -C /tmp && \
     rm /tmp/thrift-${THRIFT_VERSION}.tar.gz && \


### PR DESCRIPTION
In relation to https://github.com/StatesTitle/underwriter/pull/20462, upgrading the thrift version in the docker image in an attempt to resolve bridge test failures.

Might affect https://statestitle.atlassian.net/browse/CON-3526

**TODO:**

- [ ] [Push the latest image](https://doma.slack.com/archives/C01KULWG5NW/p1700176141725789?thread_ts=1700170006.692179&cid=C01KULWG5NW) `docker push statestitle/thrift:latest`

- [ ] Update the bridge DockerFile to see if it resolves the test failures