### PR TITLE
[CON-3950](resware-mssql): upgrade mssql python to 3 11

### DIFF
--- a/resware-mssql/Dockerfile
+++ b/resware-mssql/Dockerfile
@@ -1,10 +1,4 @@
 FROM mcr.microsoft.com/mssql/server:2017-CU18-ubuntu-16.04
-COPY ZscalerRootCertificate.crt /usr/local/share/ca-certificates/
-
-# Update CA certificates
-RUN apt-get update && \
-    apt-get install -y ca-certificates && \
-    update-ca-certificates
 
 # -y is not sufficient for upgrading SQL server
 ENV ACCEPT_EULA Y

--- a/resware-mssql/Dockerfile
+++ b/resware-mssql/Dockerfile
@@ -1,4 +1,10 @@
 FROM mcr.microsoft.com/mssql/server:2017-CU18-ubuntu-16.04
+COPY ZscalerRootCertificate.crt /usr/local/share/ca-certificates/
+
+# Update CA certificates
+RUN apt-get update && \
+    apt-get install -y ca-certificates && \
+    update-ca-certificates
 
 # -y is not sufficient for upgrading SQL server
 ENV ACCEPT_EULA Y
@@ -11,10 +17,31 @@ RUN apt-get update -y && \
 	apt-get install zip -y -V && \
 	apt-get install build-essential -y && \
 	apt-get install libssl-dev -y && \
-	apt-get install libffi-dev
+	apt-get install libffi-dev && \
+	apt-get install libbz2-dev -y && \
+	apt-get install libreadline-dev -y && \
+	apt-get install libsqlite3-dev -y && \
+	apt-get install tk-dev -y && \
+	apt-get install zlib1g-dev -y
+
+# Install OpenSSL from source
+RUN wget https://www.openssl.org/source/openssl-1.1.1k.tar.gz && \
+tar -xzf openssl-1.1.1k.tar.gz && \
+cd openssl-1.1.1k && \
+./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && \
+make && \
+make install && \
+cd .. && \
+rm -rf openssl-1.1.1k.tar.gz openssl-1.1.1k
+
+# Set environment variables for OpenSSL
+ENV LD_LIBRARY_PATH /usr/local/ssl/lib
+ENV CPPFLAGS -I/usr/local/ssl/include
+ENV LDFLAGS -L/usr/local/ssl/lib
+
 
 ### 2. Python
-### The following is copied from: https://github.com/docker-library/python/blob/ccfb4c011e1db901c167c8d4c3611263bd68e65c/3.7/stretch/Dockerfile
+### The following is copied from: https://github.com/docker-library/python/blob/master/3.11/bullseye/Dockerfile
 
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
@@ -28,11 +55,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		tk-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-ENV PYTHON_VERSION 3.7.0
+ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
+ENV PYTHON_VERSION 3.11.0
 
 RUN set -ex \
-	\
 	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
 	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
@@ -52,50 +78,56 @@ RUN set -ex \
 		--enable-shared \
 		--with-system-expat \
 		--with-system-ffi \
-		--without-ensurepip \
-	&& make -j "$(nproc)" \
-	&& make install \
-	&& ldconfig \
-	\
-	&& find /usr/local -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' + \
-	&& rm -rf /usr/src/python \
-	\
-	&& python3 --version
+		--with-openssl=/usr/local/ssl \
+		--without-ensurepip; \
+		nproc="$(nproc)"; \
+		EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
+		LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
+		make -j "$nproc" \
+			"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+			"LDFLAGS=${LDFLAGS:-}" \
+		; \
+	# https://github.com/docker-library/python/issues/784
+	# prevent accidental usage of a system installed libpython of the same version
+		rm python; \
+		make -j "$nproc" \
+			"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
+			"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
+			python \
+		; \
+		make install; \
+		\
+	# enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
+		bin="$(readlink -ve /usr/local/bin/python3)"; \
+		dir="$(dirname "$bin")"; \
+		mkdir -p "/usr/share/gdb/auto-load/$dir"; \
+		cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
+		\
+		cd /; \
+		rm -rf /usr/src/python; \
+		\
+		find /usr/local -depth \
+			\( \
+				\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
+				-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
+			\) -exec rm -rf '{}' + \
+		; \
+		\
+		ldconfig; \
+		\
+		export PYTHONDONTWRITEBYTECODE=1; \
+		python3 --version
 
-# make some useful symlinks that are expected to exist
-RUN cd /usr/local/bin \
-	&& ln -s idle3 idle \
-	&& ln -s pydoc3 pydoc \
-	&& ln -s python3 python \
-	&& ln -s python3-config python-config
+
+
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 18.0
+ENV PYTHON_PIP_VERSION 20.2.4
 
-RUN set -ex; \
-	\
-	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	python get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip==$PYTHON_PIP_VERSION" \
-	; \
-	pip --version; \
-	\
-	find /usr/local -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py
-
+# Install pip
+RUN wget https://bootstrap.pypa.io/get-pip.py -O get-pip.py \
+&& python3 get-pip.py \
+&& rm get-pip.py
 RUN pip install awscli
 
 ENV DOCKERIZE_VERSION v0.6.1

--- a/resware-mssql/README.md
+++ b/resware-mssql/README.md
@@ -43,3 +43,19 @@ This image is used to restore a zipped backup ResWare database.
   ```
   docker exec -e SA_PASSWORD=someGoodPass! -e RESWARE_DATABASE_NAME=ResWare -e BACKUP_ZIP_NAME=backup.zip -e BACKUP_FILE_NAME=backup.bak -e S3_BUCKET_NAME=data-dir -e AWS_ACCESS_KEY_ID=<Access Key ID> -e AWS_SECRET_ACCESS_KEY=<Secret Access Key> -e FORCE_BACK_UP_LOAD=N <container> ./load-backup.sh
   ```
+
+### Helpful tips to build docker image locally
+
+#### Avoiding SSL errors due to ZScaler
+Add the following lines to add Zscaler certs 
+
+```
+FROM mcr.microsoft.com/mssql/server:2017-CU18-ubuntu-16.04
+
+COPY ZscalerRootCertificate.crt /usr/local/share/ca-certificates/
+
+# Update CA certificates
+RUN apt-get update && \
+    apt-get install -y ca-certificates && \
+    update-ca-certificates
+```


### PR DESCRIPTION
In relation to https://discuss.circleci.com/t/docker-executor-infrastructure-upgrade/52282, upgrading python version referenced in this to Python 3.11 as 3.7 has reached end of life


`docker build --no-cache --tag statestitle/resware-mssql ./resware-mssql` was successful on local-dev

**TODO:**

docker build --tag statestitle/resware-mssql ./resware-mssql
docker tag  statestitle/resware-mssql statestitle/resware-mssql:v1.0-python3.11
docker login
docker push statestitle/resware-mssql:v1.0-python3.11
