### PR TITLE
[CON-3950](resware-mssql): upgrade mssql base image to 2019-CU26-ubuntu-20.04

### DIFF
--- a/resware-mssql/Dockerfile
+++ b/resware-mssql/Dockerfile
@@ -1,7 +1,34 @@
-FROM mcr.microsoft.com/mssql/server:2017-CU18-ubuntu-16.04
+FROM mcr.microsoft.com/mssql/server:2019-CU26-ubuntu-20.04
+COPY ZscalerRootCertificate.crt /usr/local/share/ca-certificates/
+
+# Switch to root user to create the directory and set permissions
+USER root
+RUN mkdir -p /var/lib/apt/lists/partial && \
+    chmod 755 /var/lib/apt/lists/partial
+
+# Install curl and gnupg
+RUN apt-get update && \
+    apt-get install -y curl gnupg
+
+
+# Update CA certificates
+RUN apt-get install -y ca-certificates && \
+    update-ca-certificates
+
+# Clean up duplicate entries
+RUN rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/mssql-release
+
+ # Add Microsoft keys and repositories
+ RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+     curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list -o /etc/apt/sources.list.d/microsoft-prod.list
+
 
 # -y is not sufficient for upgrading SQL server
 ENV ACCEPT_EULA Y
+
+
+# Fix permissions for /var/lib/apt/lists
+RUN chmod -R 755 /var/lib/apt/lists
 
 RUN apt-get update -y && \
 	apt-get dist-upgrade -y && \
@@ -15,7 +42,6 @@ RUN apt-get update -y && \
 	apt-get install libbz2-dev -y && \
 	apt-get install libreadline-dev -y && \
 	apt-get install libsqlite3-dev -y && \
-	apt-get install tk-dev -y && \
 	apt-get install zlib1g-dev -y
 
 # Install OpenSSL from source
@@ -34,6 +60,13 @@ ENV CPPFLAGS -I/usr/local/ssl/include
 ENV LDFLAGS -L/usr/local/ssl/lib
 
 
+# Install the ODBC driver for SQL Server
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update && \
+    ACCEPT_EULA=Y apt-get install -y msodbcsql18
+
+
 ### 2. Python
 ### The following is copied from: https://github.com/docker-library/python/blob/master/3.11/bullseye/Dockerfile
 
@@ -43,18 +76,16 @@ ENV PATH /usr/local/bin:$PATH
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
-
-# extra dependencies (over what buildpack-deps already includes)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		tk-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
 ENV GPG_KEY A035C8C19219BA821ECEA86B64E628F8D684696D
 ENV PYTHON_VERSION 3.11.0
 
+# Install dependencies for Python
+RUN apt-get update && \
+    apt-get install -y libexpat1-dev
+
 RUN set -ex \
-	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
-	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+	&& wget --no-check-certificate  -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+	&& wget --no-check-certificate  -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver keyserver.ubuntu.com --recv-keys "$GPG_KEY" \
 	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
@@ -75,51 +106,20 @@ RUN set -ex \
 		--with-openssl=/usr/local/ssl \
 		--without-ensurepip; \
 		nproc="$(nproc)"; \
-		EXTRA_CFLAGS="$(dpkg-buildflags --get CFLAGS)"; \
-		LDFLAGS="$(dpkg-buildflags --get LDFLAGS)"; \
-		make -j "$nproc" \
-			"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
-			"LDFLAGS=${LDFLAGS:-}" \
-		; \
-	# https://github.com/docker-library/python/issues/784
-	# prevent accidental usage of a system installed libpython of the same version
-		rm python; \
-		make -j "$nproc" \
-			"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}" \
-			"LDFLAGS=${LDFLAGS:--Wl},-rpath='\$\$ORIGIN/../lib'" \
-			python \
-		; \
-		make install; \
-		\
-	# enable GDB to load debugging data: https://github.com/docker-library/python/pull/701
-		bin="$(readlink -ve /usr/local/bin/python3)"; \
-		dir="$(dirname "$bin")"; \
-		mkdir -p "/usr/share/gdb/auto-load/$dir"; \
-		cp -vL Tools/gdb/libpython.py "/usr/share/gdb/auto-load/$bin-gdb.py"; \
-		\
-		cd /; \
-		rm -rf /usr/src/python; \
-		\
-		find /usr/local -depth \
-			\( \
-				\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
-				-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \) \) \
-			\) -exec rm -rf '{}' + \
-		; \
-		\
-		ldconfig; \
-		\
-		export PYTHONDONTWRITEBYTECODE=1; \
-		python3 --version
-
-
-
+		make -j "$nproc" && \
+		make install && \
+		cd / && \
+		rm -rf /use/src/python && \
+		find /usr/local -depth \( -type d -a \( -name test -o -name tests -o -name idle_test \) \) -exec rm -rf '{}' + && \
+    	ldconfig && \
+    	export PYTHONDONTWRITEBYTECODE=1 && \
+    	python3 --version
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
 ENV PYTHON_PIP_VERSION 20.2.4
 
 # Install pip
-RUN wget https://bootstrap.pypa.io/get-pip.py -O get-pip.py \
+RUN wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py -O get-pip.py \
 && python3 get-pip.py \
 && rm get-pip.py
 RUN pip install awscli
@@ -127,9 +127,12 @@ RUN pip install awscli
 ENV DOCKERIZE_VERSION v0.6.1
 
 # Install Docker
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+RUN wget --no-check-certificate https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+# Switch back to the default user
+USER mssql
 
 COPY load-backup.sh /
 COPY cmd.sh /

--- a/resware-mssql/Dockerfile
+++ b/resware-mssql/Dockerfile
@@ -131,9 +131,6 @@ RUN wget --no-check-certificate https://github.com/jwilder/dockerize/releases/do
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-# Switch back to the default user
-USER mssql
-
 COPY load-backup.sh /
 COPY cmd.sh /
 


### PR DESCRIPTION
In relation to https://discuss.circleci.com/t/docker-executor-infrastructure-upgrade/52282, upgrading mssql base image to 2019-CU26-ubuntu-20.04 as recommended by CircleCi

docker build --no-cache --tag statestitle/resware-mssql:v2.0-mssql2019 ./resware-mssql on local-dev

Pushed the image to dockerhub https://hub.docker.com/repository/docker/statestitle/resware-mssql/tags
```
docker login
docker push statestitle/resware-mssql:v2.0-mssql2019
```

**TODO:**
- [ ]  Find a way to remove `--no-check-certificate`, could be a ZScaler thing